### PR TITLE
Fix npm not found problem on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN go mod download
 # Copy the rest of the files and build the server
 COPY . .
 COPY --from=builder_node /code/_ui/build /code/_ui/build
-RUN make build
+RUN make build/server
 
 ############################
 # STEP 3 build a small image to run it all


### PR DESCRIPTION
This change fixes a docker build error due to npm not available in step2.
I think that building only the server part is the required make target.

Thanks for the article and code example.